### PR TITLE
Add "Try it" button to front page

### DIFF
--- a/css/index.css
+++ b/css/index.css
@@ -152,6 +152,7 @@ div.button {
 div.showcase div.button {
   float: right;
   margin: 11pt;
+  clear: right;
 }
 div.button a,
 div.button a:active {

--- a/index.html
+++ b/index.html
@@ -77,6 +77,7 @@ $(function() {
       <div class="feature"><img src="img/screenshot.png" alt="" /></div>
       <h1><strong>Etherpad</strong> is a highly customizable <strong>Open Source</strong> online editor providing collaborative editing in really <strong>real-time</strong>.</h1>
       <div class="button"><a href="#download"><i class="icon-download-alt"></i>DOWNLOAD</a><br/><span>Version 1.5.6</span></div>
+      <div class="button"><a href="https://demo.sandstorm.io/appdemo/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60"><i class="icon-arrow-right"></i>Or try a demo</a><br/></div>
     </div>
   </div>
   


### PR DESCRIPTION
Hi Etherpad maintainers,

I was emailing with @JohnMcLear recently about adding a "Try it" button to the Etherpad front page. This pull request adds such a button, with the idea that people who visit the Etherpad site can get a quick feel for how the app works by trying it, and this would hopefully make them more likely to install it on their own server. Feedback welcome!

Some context: I work on Sandstorm, an open source project that makes it easy for people to install web apps on their own servers, and we run a public server to let people try out things that are packaged for Sandstorm. You can read more about the app demo links here: https://blog.sandstorm.io/news/2015-02-06-app-demo.html

The "Try it" button goes to the Sandstorm package for Etherpad. Here's a direct link: https://demo.sandstorm.io/appdemo/h37dm17aa89yrd8zuqpdn36p6zntumtv08fjpu8a8zrte7q1cn60

One thing John and I talked about by email is the question of how to make sure the packaging is kept up-to-date for security and other updates. @kentonv is the maintainer of Etherpad within Sandstorm. The answer we came up with is:

* For security updates, we'll be BCC:'d on CVE requests (thanks greatly to @fungi for that), and
* For regular updates, we'll notice them by the Atom feed at https://github.com/ether/etherpad-lite/releases.atom (which I've subscribed to)

Let me know if you like this, and/or if there's anything I can change that would make it better. Thanks!

## Technical notes

This change also sets `div.showcase div.button` to be `clear: right;` so that the two buttons end up right-aligned.

I chose the `icon-arrow-right` imagery for the button; feel free to suggest a different icon if one is more appropriate!