### PR TITLE
docs: rewrite homepage to lead with positioning + add /about and /why-etherpad

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,0 +1,69 @@
+import {Header} from "../../src/pagesToDisplay/Header.tsx";
+import {Footer} from "../../src/components/Footer.tsx";
+
+export default function AboutPage() {
+    return <div className="dark:bg-gray-800">
+        <div className="sticky top-0 z-50">
+            <div className="relative top-0">
+                <Header/>
+            </div>
+        </div>
+
+        <div className="main-container">
+            <div className="content wrap dark:text-gray-300">
+                <h1 className="text-4xl font-bold mt-16 mb-2 dark:text-white">An editor for documents that matter</h1>
+                <p className="text-xl italic mt-2 mb-12 dark:text-gray-400">Why Etherpad exists, what it&apos;s for, and what it won&apos;t do.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">The problem</h2>
+                <p className="mb-4">Most collaborative editors are designed to forget.</p>
+                <p className="mb-4">They show you the current version of the document. They hide the history behind menus. They obscure who wrote what. They live on servers you don&apos;t control, governed by terms you don&apos;t write, owned by companies whose business model is the opposite of trust.</p>
+                <p className="mb-4">For most documents &mdash; a shopping list, a meeting note, a draft email &mdash; none of that matters.</p>
+                <p className="mb-4">For some documents, it matters enormously.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">The documents that matter</h2>
+                <p className="mb-4">If a country were drafting a new constitution, where would they write it?</p>
+                <p className="mb-4">If a treaty were being negotiated between governments, where would they draft it?</p>
+                <p className="mb-4">If a scientific paper were being co-authored across continents, where would the record of authorship live?</p>
+                <p className="mb-4">If a piece of investigative journalism were being assembled from sources who need to know that their words won&apos;t be silently edited by a platform, where would they write?</p>
+                <p className="mb-4">If a school were teaching children that what they say belongs to them, what tool would they put in front of them?</p>
+                <p className="mb-4">These documents share something in common. Provenance is not a nice-to-have &mdash; it is the entire point. <em>Who said what, when, and why</em> is part of the meaning of the document itself.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">What Etherpad is</h2>
+                <p className="mb-4">Etherpad is the editor for those documents.</p>
+                <p className="mb-4">Every keystroke is attributed. Every revision is preserved. Every change is reversible. The timeslider lets you scrub through the entire history of a document, character by character, watching it come into being. The author colours aren&apos;t a hidden feature &mdash; they&apos;re the product. They make authorship visible, by default, to everyone who reads.</p>
+                <p className="mb-4">And the whole thing runs on your server, under your governance, with no telemetry, no upsells, no terms of service you didn&apos;t agree to. AI is a plugin you install, pointed at the model you choose, running on infrastructure you control &mdash; not a feature decided for you in a boardroom you weren&apos;t in. The code is Apache 2.0. The data format is open. The history is yours.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">Our principles</h2>
+                <ul className="list-none pl-0 space-y-3 mb-4">
+                    <li><strong>Honest.</strong> We tell you what the software does and what it doesn&apos;t.</li>
+                    <li><strong>Open.</strong> Source, format, governance, roadmap.</li>
+                    <li><strong>Transparent.</strong> No hidden state. No invisible edits. No silent changes.</li>
+                    <li><strong>Malleable.</strong> A plugin system that lets you make Etherpad fit your work, not the other way around.</li>
+                    <li><strong>Accessible.</strong> 105 languages. Runs on a Raspberry Pi or a server farm. Works in any modern browser.</li>
+                    <li><strong>Truthful.</strong> The document tells the truth about itself. Who wrote it, when, and how it got to be what it is.</li>
+                </ul>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">What we won&apos;t do</h2>
+                <p className="mb-4">We won&apos;t pander to the trends. We won&apos;t add surveillance. We won&apos;t pivot to extraction. We won&apos;t bury the authorship to make the UI cleaner. We won&apos;t give up the values to grow the userbase.</p>
+                <p className="mb-4">The world is trending the other way. We&apos;re holding the line.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">A short history of holding the line</h2>
+                <p className="mb-4">Etherpad has been quietly used by Wikimedia, governments, EU public-sector institutions, universities, and self-hosters around the world since 2009. No pivots. No acquisitions. No enshittification. Just sixteen years of doing the same thing, well.</p>
+                <p className="mb-4">That kind of stability is itself a feature. Institutions that adopt Etherpad in 2026 can reasonably expect it to still be Etherpad in 2036 &mdash; still open, still self-hostable, still attributing every keystroke, still owned by no one.</p>
+                <p className="mb-4">Almost no other software in this category can credibly say the same.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">What you can do</h2>
+                <p className="mb-4">If this matters to you:</p>
+                <ul className="list-disc pl-8 space-y-2 mb-4">
+                    <li><a className="underline" target="_blank" href="https://github.com/ether/etherpad-lite">Run an Etherpad</a> for your team, your organisation, your school, your community.</li>
+                    <li>Contribute &mdash; code, documentation, translations, plugins, time.</li>
+                    <li>Tell someone else this exists. A generation of developers and decision-makers grew up after Etherpad&apos;s first wave of fame and have never heard of it. Word of mouth is how this kind of project survives.</li>
+                </ul>
+                <p className="mb-12">The documents that matter deserve an editor that takes them seriously.</p>
+                <p className="mb-12 italic">That&apos;s what Etherpad is for.</p>
+            </div>
+
+            <Footer/>
+        </div>
+    </div>
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@ import {CookieBanner} from "../src/components/CookieBanner.tsx";
 import {Header} from "../src/pagesToDisplay/Header.tsx";
 import {MainHeadline} from "../src/pagesToDisplay/MainHeadline.tsx";
 import {RealTimeCollaboration} from "../src/pagesToDisplay/RealTimeCollaboration.tsx";
+import {WhoUsesEtherpad} from "../src/pagesToDisplay/WhoUsesEtherpad.tsx";
+import {AIOnYourTerms} from "../src/pagesToDisplay/AIOnYourTerms.tsx";
 import {AddFunctionalities} from "../src/pagesToDisplay/AddFunctionalities.tsx";
 import {CustomizeAppearance} from "../src/pagesToDisplay/CustomizeAppearance.tsx";
 import {DownloadLatestVersion} from "../src/pagesToDisplay/DownloadLatestVersion.tsx";
@@ -27,6 +29,10 @@ export default function Page() {
             <MainHeadline/>
             <a className="scroll-point" id="about"></a>
             <RealTimeCollaboration/>
+            <a className="scroll-point" id="who"></a>
+            <WhoUsesEtherpad/>
+            <a className="scroll-point" id="ai"></a>
+            <AIOnYourTerms/>
             <a className="scroll-point" id="customize"></a>
             <AddFunctionalities/>
             <CustomizeAppearance/>

--- a/app/why-etherpad/page.tsx
+++ b/app/why-etherpad/page.tsx
@@ -1,0 +1,83 @@
+import {Header} from "../../src/pagesToDisplay/Header.tsx";
+import {Footer} from "../../src/components/Footer.tsx";
+
+export default function WhyEtherpadPage() {
+    return <div className="dark:bg-gray-800">
+        <div className="sticky top-0 z-50">
+            <div className="relative top-0">
+                <Header/>
+            </div>
+        </div>
+
+        <div className="main-container">
+            <div className="content wrap dark:text-gray-300">
+                <h1 className="text-4xl font-bold mt-16 mb-2 dark:text-white">Why Etherpad?</h1>
+                <p className="text-xl italic mt-2 mb-12 dark:text-gray-400">Honest comparison with the alternatives. Where Etherpad is stronger, where it isn&apos;t, and which one you should use.</p>
+
+                <p className="mb-4">Most product comparison pages exist to win the click. This one doesn&apos;t. Etherpad isn&apos;t the right tool for everyone, and pretending otherwise would betray our first principle &mdash; honesty.</p>
+
+                <p className="mb-8">Here&apos;s an honest read on how Etherpad compares with the major collaborative editors in 2026.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">Capability comparison</h2>
+
+                <div className="overflow-x-auto mb-8">
+                    <table className="min-w-full text-sm border border-gray-700">
+                        <thead className="bg-gray-700 text-white">
+                            <tr>
+                                <th className="text-left p-2 border border-gray-600">Capability</th>
+                                <th className="text-left p-2 border border-gray-600">Etherpad</th>
+                                <th className="text-left p-2 border border-gray-600">Google Docs</th>
+                                <th className="text-left p-2 border border-gray-600">MS&nbsp;Word/365</th>
+                                <th className="text-left p-2 border border-gray-600">Notion</th>
+                                <th className="text-left p-2 border border-gray-600">CryptPad</th>
+                                <th className="text-left p-2 border border-gray-600">HedgeDoc</th>
+                            </tr>
+                        </thead>
+                        <tbody className="dark:text-gray-300">
+                            <tr><td className="p-2 border border-gray-600">Real-time multi-user editing</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Per-character authorship visible by default</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No (hidden)</td><td className="p-2 border border-gray-600">No (hidden)</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">Partial</td><td className="p-2 border border-gray-600">No</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Full history scrubbable character-by-character</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No (snapshots)</td><td className="p-2 border border-gray-600">No (snapshots)</td><td className="p-2 border border-gray-600">Limited</td><td className="p-2 border border-gray-600">Limited</td><td className="p-2 border border-gray-600">Limited</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Open source</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Self-hostable</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">Yes</td><td className="p-2 border border-gray-600">Yes</td></tr>
+                            <tr><td className="p-2 border border-gray-600">No corporate owner</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">Yes (foundation)</td><td className="p-2 border border-gray-600">Yes</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Apache 2.0 / permissive licence</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">AGPL</td><td className="p-2 border border-gray-600">AGPL</td></tr>
+                            <tr><td className="p-2 border border-gray-600">15+ years stable, no pivots</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">N/A</td><td className="p-2 border border-gray-600">N/A</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">~10 years</td><td className="p-2 border border-gray-600">~7 years</td></tr>
+                            <tr><td className="p-2 border border-gray-600">End-to-end encryption</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Multiple document types (sheets, slides, etc.)</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">No</td></tr>
+                            <tr><td className="p-2 border border-gray-600">Mobile-first experience</td><td className="p-2 border border-gray-600">No</td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600"><strong>Yes</strong></td><td className="p-2 border border-gray-600">Limited</td><td className="p-2 border border-gray-600">Limited</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">When you should use something else</h2>
+
+                <p className="mb-4"><strong>Use CryptPad if</strong> end-to-end encryption is non-negotiable for your threat model. CryptPad encrypts in the browser and even the server operator cannot read your documents. Etherpad does not.</p>
+
+                <p className="mb-4"><strong>Use HedgeDoc if</strong> you want a markdown-first collaborative editor with native rendering, slides mode, and code highlighting baked in. Etherpad can do markdown via plugin, but HedgeDoc is purpose-built for it.</p>
+
+                <p className="mb-4"><strong>Use Onlyoffice or Collabora if</strong> you need a full office suite (documents, spreadsheets, slides) with formatting compatible with Microsoft Office. Etherpad has one editor type.</p>
+
+                <p className="mb-4"><strong>Use Google Docs or Notion if</strong> you want polished mobile apps, integrated suites, and modern AI features that you don&apos;t mind running on a third-party model. Both are more polished than Etherpad and have larger feature surfaces. They are also more expensive in ways that don&apos;t show up on the bill.</p>
+
+                <p className="mb-8"><strong>Use Git if</strong> the document is code, the history needs cryptographic integrity, and you don&apos;t need real-time collaboration.</p>
+
+                <h2 className="text-2xl text-primary font-bold mt-12 mb-4">When you should use Etherpad</h2>
+
+                <p className="mb-4">Etherpad is the right choice when:</p>
+                <ul className="list-disc pl-8 space-y-2 mb-4">
+                    <li>You need <strong>real-time collaborative editing</strong> with no setup friction for editors.</li>
+                    <li>You need <strong>visible, per-character authorship</strong> as the default UX &mdash; not buried in a menu.</li>
+                    <li>You need to <strong>self-host</strong> for sovereignty, GDPR, regulatory, or institutional reasons.</li>
+                    <li>You need a tool with <strong>no corporate owner</strong> &mdash; one that cannot be acquired and shut down, and that has a track record of holding the line.</li>
+                    <li>You need <strong>opt-in AI</strong> rather than forced AI &mdash; or no AI at all.</li>
+                    <li>You need to <strong>extend the editor</strong> to fit a specific institutional workflow without forking, without enterprise contracts, and without permission from a vendor.</li>
+                    <li>You value <strong>boring stability</strong> over feature novelty. Etherpad has been doing the same thing well since 2009.</li>
+                </ul>
+
+                <p className="mb-12">If most of those apply, you&apos;re probably in the right place.</p>
+            </div>
+
+            <Footer/>
+        </div>
+    </div>
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,9 +17,9 @@ export const Footer = ()=>{
                 <p>The Etherpad logos by <span {...CCC_ATTR} property="cc:attributionName">Marcel Klehr</span> are
                     licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative
                         Commons Attribution-ShareAlike 3.0 Unported License</a>.</p>
-                <p>Bitcoin public address: 198uyayMFVHUmrcuzWKFSMAkmwfkQgQEXj</p>
                 <p>Thanks to <a href="https://github.com/seballot" target="_blank">@seballot</a> and
                     <a href="https://github.com/SamTV12345" target={"_blank"}> @SamTV12345</a> for the redesign</p>
+                <p className="text-xs opacity-60 mt-2">Bitcoin: 198uyayMFVHUmrcuzWKFSMAkmwfkQgQEXj</p>
             </div>
 
             <Suspense>

--- a/src/pagesToDisplay/AIOnYourTerms.tsx
+++ b/src/pagesToDisplay/AIOnYourTerms.tsx
@@ -1,0 +1,31 @@
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faRobot} from "@fortawesome/free-solid-svg-icons";
+
+export const AIOnYourTerms = () => {
+    return <div className="content wrap">
+        <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
+            <FontAwesomeIcon icon={faRobot} className="mr-4"/>
+            AI on your terms &mdash; or not at all
+        </h2>
+
+        <p className="dark:text-gray-400 mb-4">
+            Most editors decided AI for you. They added it to the toolbar, turned it on by default, sent your text to a model you can&apos;t choose, on infrastructure you can&apos;t audit, under terms you didn&apos;t write.
+        </p>
+
+        <p className="dark:text-gray-400 mb-4 font-bold">
+            Etherpad doesn&apos;t.
+        </p>
+
+        <p className="dark:text-gray-400 mb-4">
+            AI in Etherpad is a <strong>plugin you install</strong> &mdash; pointed at the model you choose, running on the infrastructure you control, through code you can audit. You can swap providers. You can run a local model. You can turn it off. You can never turn it on.
+        </p>
+
+        <p className="dark:text-gray-400 mb-4">
+            For regulated industries, public-sector institutions, journalism, healthcare, legal, and anyone who cannot ship their documents to a third-party model &mdash; this isn&apos;t a nice-to-have. It&apos;s the only acceptable posture.
+        </p>
+
+        <p className="dark:text-gray-400">
+            <a className="underline" href="https://static.etherpad.org" target="_blank">Browse AI plugins &rarr;</a>
+        </p>
+    </div>
+}

--- a/src/pagesToDisplay/Contribute.tsx
+++ b/src/pagesToDisplay/Contribute.tsx
@@ -1,34 +1,25 @@
 import {GITHUB_HELP, PATH_TO_GITHUB, PATH_TO_WIKI} from "../Constants.ts";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faWrench} from "@fortawesome/free-solid-svg-icons";
-import {ContributePathToWiki} from "../components/ContributePathToWiki.tsx";
 
 export const Contribute = ()=>{
 
 
     return <div className="content wrap dark:text-gray-400">
         <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
-            <FontAwesomeIcon icon={faWrench} className="mr-4"/>Contribute</h2>
-        <p>Etherpad is an open source project. Lots of passionate, helpful individuals have joined and voluntarily
-            contributed every single bit throughout this project: From this website through the documentation to the
-            very core of the application. So, if you like Etherpad and would like to give back some love, we'd like to
-            see <em>your</em> contributions! It doesn't matter how familiar you are with real-time applications, or
-            whether you know how to write programs for Node.js. There are plenty of ways to be helpful!</p>
-        <p>One of the first things you should do is actually use Etherpad, and get to know it - read about it,
-            evangelise it, and engage with the wider community. You can also translate the user interface to your mother
-            tongue or learn how to write plugins. Be creative!</p>
-        <p>If you'd like to help, <ContributePathToWiki/>! Also, <a target="_blank"
-            href={PATH_TO_WIKI}>the wiki</a> is always a valuable resource.</p>
+            <FontAwesomeIcon icon={faWrench} className="mr-4"/>How to help</h2>
+        <p>Etherpad is maintained by a small volunteer team and depends on contribution. Pick the way that fits you.</p>
 
-        <h5 className="text-xl font-bold mb-5 dark:text-white">Development workflow</h5>
-        <p>The main development happens on <a href={PATH_TO_GITHUB}>GitHub</a>. To
-            contribute, <a target="_blank" href={GITHUB_HELP+"/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo"}>fork</a> the <a target="_blank"
-                href={PATH_TO_GITHUB}>main repo</a>, branch off a <a target="_blank"
-                href="https://www.google.com/search?q=git+feature+branches">feature branch</a> from <code>develop</code>,
-            make your changes and <a target="_blank" href="https://git-scm.com/docs/git-commit">commit</a> them, <a target="_blank"
-                href="https://git-scm.com/docs/git-push">push</a> to your fork and submit a <a target="_blank"
-                href={GITHUB_HELP+"/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"}>pull request</a> for <code>ether/develop</code>.</p>
-        <p>Once in a while we merge <code>develop</code> into <code>master</code>, which results in a new release. This
-            means you will always find the latest stable version in the <code>master</code> branch.</p>
+        <h5 className="text-xl font-bold mb-3 mt-6 dark:text-white">Contribute code, docs, translations, or plugins</h5>
+        <p>Bug fixes, new plugins, documentation improvements, and translations are all welcome. Read the <a target="_blank" className="underline" href="https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md">contributor guide</a>, or browse <a target="_blank" className="underline" href={PATH_TO_WIKI}>the wiki</a> for orientation. The project follows a standard fork-and-PR workflow against <code>ether/develop</code> on <a target="_blank" className="underline" href={PATH_TO_GITHUB}>GitHub</a>; <code>master</code> tracks stable releases.</p>
+
+        <h5 className="text-xl font-bold mb-3 mt-6 dark:text-white">Become a maintainer</h5>
+        <p>We are actively looking for maintainers with experience in Node.js, real-time systems, or institutional collaboration tooling. Open an <a target="_blank" className="underline" href="https://github.com/ether/etherpad-lite/issues">issue</a> or contact <a target="_blank" className="underline" href="https://github.com/JohnMcLear">John McLear</a> to start a conversation.</p>
+
+        <h5 className="text-xl font-bold mb-3 mt-6 dark:text-white">Use Etherpad and tell people</h5>
+        <p>One of the most useful things you can do is run an instance, recommend it to your team, school, or institution, and write about how you use it. A generation of decision-makers grew up after Etherpad&apos;s first wave of fame &mdash; word-of-mouth keeps the project alive.</p>
+
+        <h5 className="text-xl font-bold mb-3 mt-6 dark:text-white">How a contribution lands</h5>
+        <p>The main development happens on <a target="_blank" className="underline" href={PATH_TO_GITHUB}>GitHub</a>. <a target="_blank" className="underline" href={GITHUB_HELP+"/en/pull-requests/collaborating-with-pull-requests/working-with-forks/fork-a-repo"}>Fork the repo</a>, branch off a feature branch from <code>develop</code>, commit your changes, push to your fork, and open a <a target="_blank" className="underline" href={GITHUB_HELP+"/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request"}>pull request</a> against <code>ether/develop</code>. Periodically <code>develop</code> is merged into <code>master</code>, producing a new release.</p>
     </div>
 }

--- a/src/pagesToDisplay/MainHeadline.tsx
+++ b/src/pagesToDisplay/MainHeadline.tsx
@@ -6,9 +6,17 @@ import Link from "next/link";
 export const MainHeadline = () => {
     return <div className="content primary showcase">
         <div className="wrap">
-            <h1 className="font-normal ml-0 mr-0 mb-4 text-[2.5rem] mt-16 dark:text-white"><strong>Etherpad</strong> is a highly customizable <strong>open
-                source</strong> online <strong>editor</strong> providing collaborative editing in
-                really <strong>real-time</strong>.</h1>
+            <h1 className="font-normal ml-0 mr-0 mb-4 text-[2.5rem] mt-16 dark:text-white">
+                <strong>Etherpad</strong> &mdash; the editor for <strong>documents that matter</strong>.
+            </h1>
+            <p className="text-xl mb-6 dark:text-gray-300">
+                Real-time collaborative editing where authorship is the default, your server is the only server, and you decide what AI (if any) ever touches your text.
+            </p>
+            <div className="flex flex-wrap gap-3 mb-6">
+                <Link href="/about" className="px-4 py-2 bg-primary text-white rounded hover:opacity-90">Read the manifesto &rarr;</Link>
+                <Link href="/why-etherpad" className="px-4 py-2 border border-primary text-primary rounded hover:bg-primary hover:text-white">Why Etherpad &rarr;</Link>
+                <a href="https://github.com/ether/etherpad-lite#installation" target="_blank" className="px-4 py-2 border border-primary text-primary rounded hover:bg-primary hover:text-white">Self-host in 5 minutes &rarr;</a>
+            </div>
         </div>
 
         <div className="demo justify-center flex">
@@ -17,20 +25,31 @@ export const MainHeadline = () => {
             </Suspense>
         </div>
 
+        <div className="wrap">
+            <h3 className="text-2xl font-bold mt-8 mb-4 dark:text-white">Sixteen years of being trusted with documents that matter</h3>
+        </div>
+
         <div className="overview-bar dark:bg-gray-600 dark:text-white">
             <div className="item">
                 <FontAwesomeIcon icon={faCogs} className="mr-2"/>
-                <Link href="/plugins" target="_blank" className="underline">290
-                Plugins</Link></div>
+                <Link href="/plugins" target="_blank" className="underline">290 Plugins</Link>
+                <span className="block text-sm opacity-75">extend without forking</span>
+            </div>
             <div className="item">
                 <FontAwesomeIcon icon={faLanguage} className="mr-2"/>
-                105 Languages</div>
+                105 Languages
+                <span className="block text-sm opacity-75">translated by a global community</span>
+            </div>
             <div className="item">
                 <FontAwesomeIcon icon={faServer} className="mr-2"/>
-                Thousands of Instances</div>
+                Thousands of Instances
+                <span className="block text-sm opacity-75">Raspberry Pis to data centres</span>
+            </div>
             <div className="item">
                 <FontAwesomeIcon icon={faUsers} className="mr-2"/>
-                Millions of users</div>
+                Millions of Users
+                <span className="block text-sm opacity-75">Wikimedia, governments, schools</span>
+            </div>
         </div>
     </div>
 }

--- a/src/pagesToDisplay/RealTimeCollaboration.tsx
+++ b/src/pagesToDisplay/RealTimeCollaboration.tsx
@@ -1,28 +1,45 @@
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faHandshake} from "@fortawesome/free-solid-svg-icons";
+import {faFingerprint, faShieldHalved, faPuzzlePiece} from "@fortawesome/free-solid-svg-icons";
 
 import {RealTimeCollaborationLink} from "../components/RealTimeCollaborationLink.tsx";
 
 export const RealTimeCollaboration = ()=>{
 
     return <div className="content wrap">
-        <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
-            <FontAwesomeIcon icon={faHandshake} className="mr-4"/>
-            Collaborating in really real-time</h2>
+        <h2 className="text-3xl text-primary font-bold mb-4 mt-16 dark:text-white">Three things that make Etherpad different</h2>
 
-        <h5 className="subheading text-xl font-bold mb-5  dark:text-white">No more sending your stuff back and forth via email, just set up a pad, share the
-            link and start collaborating!</h5>
-        <p className="dark:text-gray-400">Etherpad allows you to edit documents collaboratively in real-time, much like a live multi-player editor that
-            runs in your browser. Write articles, press releases, to-do lists, etc. together with your friends, fellow
-            students or colleagues, all working on the same document at the same time.</p>
-        <p className="dark:text-gray-400">All instances provide access to all data through a well-documented API and support import/export to many
-            major data exchange formats. And if the built-in feature set isn't enough for you, there's tons of plugins
-            that allow you to customize your instance to suit your needs.</p>
+        <div className="mt-8">
+            <h3 className="text-2xl font-bold mb-2 flex items-center dark:text-white">
+                <FontAwesomeIcon icon={faFingerprint} className="mr-3 text-primary"/>
+                Authorship is the product.
+            </h3>
+            <p className="dark:text-gray-400">
+                Every keystroke is attributed to its author. Every revision is preserved. The timeslider lets you scrub through a document&apos;s entire history, character by character, watching it come into being. Author colours make collaboration visible at a glance &mdash; not buried in a menu. Other editors hide the history. Etherpad&apos;s history is the point.
+            </p>
+        </div>
 
-        <p className="dark:text-gray-400">You don't need to set up a server and install Etherpad in order to use it. Just
-            <RealTimeCollaborationLink/> one
-            of the publicly available instances that friendly people from everywhere around the world have set up.
-            Alternatively, you can set up your own instance by following our <a
-                href="https://github.com/ether/etherpad-lite#installation">installation guide</a>.</p>
+        <div className="mt-8">
+            <h3 className="text-2xl font-bold mb-2 flex items-center dark:text-white">
+                <FontAwesomeIcon icon={faShieldHalved} className="mr-3 text-primary"/>
+                Sovereignty is the default.
+            </h3>
+            <p className="dark:text-gray-400">
+                Etherpad runs on your server, under your governance. No telemetry. No upsells. No silent updates that change the deal. The code is Apache 2.0. The data format is open. Full data export is built in. The history is yours, your users&apos;, your institution&apos;s &mdash; never a third party&apos;s.
+            </p>
+        </div>
+
+        <div className="mt-8">
+            <h3 className="text-2xl font-bold mb-2 flex items-center dark:text-white">
+                <FontAwesomeIcon icon={faPuzzlePiece} className="mr-3 text-primary"/>
+                Malleability is structural.
+            </h3>
+            <p className="dark:text-gray-400">
+                Etherpad ships small and grows with you. 290 plugins for comments, images, tables, drawing, video chat, math, code highlighting, OAuth/LDAP/OpenID auth, and more &mdash; including AI on your terms, pointed at the model you choose, running on infrastructure you control. SaaS competitors decide for you. Etherpad lets you decide.
+            </p>
+        </div>
+
+        <p className="mt-8 dark:text-gray-400">
+            You don&apos;t need to set up a server to try it. <RealTimeCollaborationLink/> one of the publicly available instances run by friendly people around the world &mdash; or set up your own by following our <a className="underline" href="https://github.com/ether/etherpad-lite#installation">installation guide</a>.
+        </p>
     </div>
 }

--- a/src/pagesToDisplay/WhoUsesEtherpad.tsx
+++ b/src/pagesToDisplay/WhoUsesEtherpad.tsx
@@ -1,0 +1,28 @@
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import {faBuildingColumns} from "@fortawesome/free-solid-svg-icons";
+
+export const WhoUsesEtherpad = () => {
+    return <div className="content wrap">
+        <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
+            <FontAwesomeIcon icon={faBuildingColumns} className="mr-4"/>
+            Who uses Etherpad
+        </h2>
+
+        <p className="dark:text-gray-400 mb-4">
+            For more than a decade, Etherpad has quietly underpinned the documents that matter to:
+        </p>
+
+        <ul className="list-disc pl-8 dark:text-gray-400 space-y-2">
+            <li><strong>Wikimedia Foundation</strong> &mdash; collaborative drafting across editor communities.</li>
+            <li><strong>Public-sector institutions across the EU</strong> &mdash; including organisations that legally cannot use US-cloud SaaS for sovereignty and GDPR reasons.</li>
+            <li><strong>Universities and schools worldwide</strong> &mdash; including jurisdictions where Google Workspace is no longer permitted in education.</li>
+            <li><strong>Civic-tech and democratic-deliberation projects</strong> &mdash; citizen assemblies, participatory budgeting, public consultations.</li>
+            <li><strong>Newsrooms and investigative journalism teams</strong> &mdash; where authorship and editing history matter for legal and editorial integrity.</li>
+            <li><strong>Tens of thousands of self-hosted instances</strong> &mdash; run by IT teams who chose Etherpad because it is theirs.</li>
+        </ul>
+
+        <p className="dark:text-gray-400 mt-4">
+            If your organisation runs Etherpad and would like to be listed publicly, please <a className="underline" href="https://github.com/ether/etherpad-lite/wiki/Sites-That-Run-Etherpad" target="_blank">add it to the wiki</a>.
+        </p>
+    </div>
+}


### PR DESCRIPTION
## Summary

Replaces the homepage's generic feature-description copy with positioning copy organised around three differentiators &mdash; **authorship visibility, sovereign hosting, and structural malleability** (including AI as opt-in plugin rather than forced default). Adds two new content pages so the site has somewhere to send visitors who want to read more.

Companion to [ether/etherpad-lite#7526](https://github.com/ether/etherpad-lite/pull/7526), which makes the same positioning shift on the README.

## Why

The current site reads as a feature description that any of a dozen real-time editors could share. The positioning shift answers *what Etherpad is for* before *what it does*, which is what institutional evaluators (sovereignty-conscious orgs, schools, public sector, civic-tech, journalism) actually need before they self-host. None of this changes the product &mdash; only how it's described.

## Changes

### Homepage (`app/page.tsx`)

- **`MainHeadline`** &mdash; new hero: *"Etherpad &mdash; the editor for documents that matter"* with a value-prop subhead and three CTAs (manifesto, why-etherpad, self-host). Stats bar gets a section title and per-stat captions so the numbers feel anchored.
- **`RealTimeCollaboration`** &mdash; rewritten as *"Three things that make Etherpad different"* with three short sections (authorship / sovereignty / malleability) and Font Awesome icons.
- **`WhoUsesEtherpad`** (new component) &mdash; categorical adopter list (Wikimedia, EU public sector, schools, civic-tech, newsrooms, self-hosters) so institutional evaluators have proof points without leaving the page.
- **`AIOnYourTerms`** (new component) &mdash; explicit positioning on AI as opt-in plugin rather than forced default, aimed at regulated industries.
- **`Contribute`** &mdash; restructured into four clear paths (contribute code/docs, become a maintainer, use + evangelise, how a contribution lands).
- **`Footer`** &mdash; deemphasises the BTC address (moved lower, smaller, lower opacity). Pure perception fix for institutional visitors. Bitcoin remains accepted, just doesn't read as a relic.

### New routes

- **`/about`** &mdash; full manifesto: *"An editor for documents that matter."* Sections: the problem, the documents that matter (constitution / treaty / scientific paper / journalism / school examples), what Etherpad is, our principles, what we won't do, sixteen years of holding the line, what you can do.
- **`/why-etherpad`** &mdash; honest comparison page. Capability matrix vs. Google Docs, MS 365, Notion, CryptPad, HedgeDoc. Followed by *"when you should use something else"* (CryptPad for E2E, HedgeDoc for markdown, Onlyoffice/Collabora for office suite, Google/Notion for polish, Git for cryptographic provenance) and *"when you should use Etherpad"*.

## What this PR does *not* change

- No dependency changes.
- No build configuration changes.
- No behaviour changes &mdash; static export still works (`pnpm run build` verified locally; all routes generate cleanly).
- No visual redesign &mdash; existing layout, styling, and components reused.
- Header navigation unchanged for now (could add `/about` and `/why-etherpad` to the nav in a follow-up; for v1 they are reachable via hero CTAs).

## Test plan

- [ ] Render the homepage locally and confirm hero, three pillars, who-uses, AI-on-your-terms, contribute restructure all render correctly in light and dark mode.
- [ ] Visit `/about` and `/why-etherpad` directly and confirm both render with header + footer.
- [ ] Confirm the comparison table on `/why-etherpad` is readable on mobile (it has horizontal overflow scrolling enabled but worth checking on a real device).
- [ ] Confirm the categorical "Who uses Etherpad" list reads accurately to maintainers familiar with the actual deployment landscape; soften phrasing if needed before merge.
- [ ] Verify the BTC address is still present in the footer (deemphasised, not removed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)