### PR TITLE
chore(footer): remove unverified Bitcoin donation address

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -17,7 +17,6 @@ export const Footer = ()=>{
                 <p>The Etherpad logos by <span {...CCC_ATTR} property="cc:attributionName">Marcel Klehr</span> are
                     licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-sa/3.0/">Creative
                         Commons Attribution-ShareAlike 3.0 Unported License</a>.</p>
-                <p>Bitcoin public address: 198uyayMFVHUmrcuzWKFSMAkmwfkQgQEXj</p>
                 <p>Thanks to <a href="https://github.com/seballot" target="_blank">@seballot</a> and
                     <a href="https://github.com/SamTV12345" target={"_blank"}> @SamTV12345</a> for the redesign</p>
             </div>


### PR DESCRIPTION
## Summary

Removes the Bitcoin donation address (`198uyayMFVHUmrcuzWKFSMAkmwfkQgQEXj`) that has been listed in the site footer for years. The destination wallet is **not verified** as belonging to or being monitored by current maintainers.

Leaving a public donation channel where the destination is unknown is worse than having no channel at all &mdash; well-intentioned donors could send funds that never reach the project.

## Why a separate PR?

Companion to [#361](https://github.com/ether/ether.github.com/pull/361) (the homepage positioning rewrite), but kept as its own PR because:

- This change has different reasoning (trust / fund-routing) than the positioning work.
- It can be merged independently and faster.
- If the positioning PR needs more discussion, this safety fix shouldn't be held up by it.

## Changes

- Remove the `<p>Bitcoin public address: ...</p>` line from `src/components/Footer.tsx`.

That's it. No other content affected.

## Future donation channels

If/when a verified, actively monitored donation channel (Bitcoin, OpenCollective, GitHub Sponsors, bank transfer, or otherwise) is set up, it can be re-added in a dedicated PR alongside any other supported funding routes &mdash; ideally with a `/donate` page that explains where the funds go.

## Test plan

- [ ] Render the footer locally and confirm the BTC line is gone, all other footer content is preserved.
- [ ] Confirm no other usage of the address string elsewhere in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)