### PR TITLE
ui: non-docker one-liner, remove hero CTAs/BTC, rename Functionality

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -19,7 +19,6 @@ export const Footer = ()=>{
                         Commons Attribution-ShareAlike 3.0 Unported License</a>.</p>
                 <p>Thanks to <a href="https://github.com/seballot" target="_blank">@seballot</a> and
                     <a href="https://github.com/SamTV12345" target={"_blank"}> @SamTV12345</a> for the redesign</p>
-                <p className="text-xs opacity-60 mt-2">Bitcoin: 198uyayMFVHUmrcuzWKFSMAkmwfkQgQEXj</p>
             </div>
 
             <Suspense>

--- a/src/components/InstallOneLiner.tsx
+++ b/src/components/InstallOneLiner.tsx
@@ -10,17 +10,17 @@ const ONE_LINERS: Record<OS, {label: string; command: string; icon: typeof faLin
     linux: {
         label: 'Linux',
         icon: faLinux,
-        command: 'docker run -d --name etherpad -p 9001:9001 etherpad/etherpad',
+        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad-lite/master/bin/installer.sh | sh',
     },
     mac: {
         label: 'macOS',
         icon: faApple,
-        command: 'docker run -d --name etherpad -p 9001:9001 etherpad/etherpad',
+        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad-lite/master/bin/installer.sh | sh',
     },
     windows: {
         label: 'Windows',
         icon: faWindows,
-        command: 'docker run -d --name etherpad -p 9001:9001 etherpad/etherpad',
+        command: 'irm https://raw.githubusercontent.com/ether/etherpad-lite/master/bin/installer.ps1 | iex',
     },
 };
 
@@ -70,7 +70,7 @@ export const InstallOneLiner = () => {
             </button>
         </div>
         <p className="text-xs text-gray-500 dark:text-gray-400 px-3 pb-3">
-            Needs Docker. Then open <code>http://localhost:9001</code>.{' '}
+            Needs <code>git</code> and Node.js &ge; 20. Then <code>cd etherpad-lite && pnpm run prod</code> and open <code>http://localhost:9001</code>.{' '}
             <a
                 href="https://github.com/ether/etherpad-lite#installation"
                 target="_blank"

--- a/src/pagesToDisplay/AddFunctionalities.tsx
+++ b/src/pagesToDisplay/AddFunctionalities.tsx
@@ -7,7 +7,7 @@ export const AddFunctionalities = ()=>{
     return <div className="content wrap">
         <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
             <FontAwesomeIcon icon={faPlug} className="mr-4"/>
-            Add Functionalities</h2>
+            Add Functionality</h2>
         <span className="dark:text-gray-400">
         Etherpad is very customizable through plugins. Instructions can be found in the <a
         href={ADDITIONAL_PLUGINS} target="_blank">plugin wiki article</a>

--- a/src/pagesToDisplay/MainHeadline.tsx
+++ b/src/pagesToDisplay/MainHeadline.tsx
@@ -7,16 +7,12 @@ import {InstallOneLiner} from "../components/InstallOneLiner.tsx";
 export const MainHeadline = () => {
     return <div className="content primary showcase">
         <div className="wrap">
-            <h1 className="font-normal ml-0 mr-0 mb-4 text-[2.5rem] mt-16 dark:text-white">
+            <h1 className="font-normal ml-0 mr-0 mb-4 text-[2.3rem] mt-16 dark:text-white">
                 <strong>Etherpad</strong> &mdash; the editor for <strong>documents that matter</strong>.
             </h1>
             <p className="text-xl mb-6 dark:text-gray-300">
                 Real-time collaborative editing where authorship is the default, your server is the only server, and you decide what AI (if any) ever touches your text.
             </p>
-            <div className="flex flex-wrap gap-3 mb-6">
-                <Link href="/about" className="px-4 py-2 bg-primary text-white rounded hover:opacity-90">Read the manifesto &rarr;</Link>
-                <Link href="/why-etherpad" className="px-4 py-2 border border-primary text-primary rounded hover:bg-primary hover:text-white">Why Etherpad &rarr;</Link>
-            </div>
 
             <InstallOneLiner/>
         </div>


### PR DESCRIPTION
## Summary

Four tweaks to the home page after PRs #361 and #365 landed:

- **InstallOneLiner**: replace the Docker one-liner with the native `curl | sh` (Linux/macOS) and `irm | iex` (Windows) installers from etherpad-lite's README. Caption updated from "Needs Docker" to git + Node.js ≥ 20 with the follow-up `cd etherpad-lite && pnpm run prod` step.
- **MainHeadline**: remove the "Read the manifesto" and "Why Etherpad" CTA buttons from the `.content.primary.showcase` container. The header already links to `/about`, and the hero was getting crowded once `InstallOneLiner` landed.
- **MainHeadline**: shrink hero `<h1>` from `2.5rem` to `2.3rem` so the heading sits more naturally above the subhead.
- **AddFunctionalities**: rename heading "Add Functionalities" → "Add Functionality" — functionality reads as an uncountable collective here, which is more idiomatic.
- **Footer**: remove the unverified Bitcoin donation line that PR #361 reintroduced on top of #362.

No routing or dependency changes. The `/about` and `/why-etherpad` pages still exist, just without hero-level CTAs.

## Test plan

- [x] `pnpm run build` succeeds; all seven routes still generate as static
- [ ] Home page renders without the two CTA buttons and shows the new installer commands
- [ ] Tabs in InstallOneLiner swap between Linux / macOS (same curl command) and Windows (PowerShell irm)
- [ ] Footer no longer shows the Bitcoin line
- [ ] `/about` link from the header still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)