### PR TITLE
ui(installer): centre the one-liner box and add vertical padding

### DIFF
--- a/src/components/InstallOneLiner.tsx
+++ b/src/components/InstallOneLiner.tsx
@@ -38,7 +38,7 @@ export const InstallOneLiner = () => {
         }
     };
 
-    return <div className="mt-4 rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 overflow-hidden max-w-xl">
+    return <div className="my-8 mx-auto p-2 rounded border border-gray-300 dark:border-gray-600 bg-gray-50 dark:bg-gray-700 overflow-hidden max-w-xl">
         <div className="flex text-sm">
             {(Object.keys(ONE_LINERS) as OS[]).map((key) => {
                 const active = os === key;


### PR DESCRIPTION
## Summary

- Centre the InstallOneLiner box with `mx-auto` (was hugging the left gutter inside `.wrap`)
- Add `my-8` for vertical separation from the subhead above and demo gif below
- Add `p-2` so the tab/command/caption stack isn't flush against the border

## Test plan

- [x] `pnpm run build` succeeds
- [ ] Installer box is horizontally centred on the home page at desktop widths
- [ ] Clear space above and below the box (not crowding subhead or gif)

🤖 Generated with [Claude Code](https://claude.com/claude-code)