### PR TITLE
feat(plugins): sort by downloads descending by default

### DIFF
--- a/app/plugins/page.tsx
+++ b/app/plugins/page.tsx
@@ -66,6 +66,8 @@ export default function PluginViewer() {
                 }
             }
 
+            list.sort((a, b) => (b.downloads || 0) - (a.downloads || 0))
+
             useUIStore.getState().setPluginData(
                 {
                     downloadCount,
@@ -75,7 +77,7 @@ export default function PluginViewer() {
                     lastModified,
                     keywords: [],
                     searchKeyword: '',
-                    sortKey: 'newest',
+                    sortKey: 'downloads',
                     filterOfficial: false
                 })
         })

--- a/src/pagesToDisplay/PluginViewerHeader.tsx
+++ b/src/pagesToDisplay/PluginViewerHeader.tsx
@@ -37,6 +37,7 @@ export const PluginViewerHeader = ()=> {
             }}>
                 <SelectTrigger className="bg-gray-700 text-white border-[1px] w-1/2 pt-1 pl-2">{pluginData?.sortKey}</SelectTrigger>
                 <SelectContent className="bg-gray-700 text-white">
+                    <SelectItem className="bg-gray-700" value="downloads">Downloads</SelectItem>
                     <SelectItem className="bg-gray-700" onClick={() => {
                         setSortKey('created');
                     }} value={"created"}>Created</SelectItem>


### PR DESCRIPTION
## Summary

- Sort \`/plugins\` by monthly download count (descending) on initial load, so the top of the page is the plugins the community actually runs — instead of whatever order \`plugins.viewer.json\` happens to serialise them in (currently puts some 2021-era plugins first).
- Add **Downloads** as an explicit option in the sort dropdown and show it as the selected entry on page load. The sort logic already existed as the \`setSortKey\` fallback; this wires it to a visible dropdown item.

## Test plan

- [x] \`pnpm run build\` succeeds
- [ ] /plugins first page shows plugins with highest monthly downloads first
- [ ] Sort dropdown reads "downloads" by default and offers Downloads / Created / Updated / Newest

🤖 Generated with [Claude Code](https://claude.com/claude-code)