### PR TITLE
fix(InstallOneLiner): point installer URLs at 'develop' branch (master doesn't exist)

### DIFF
--- a/src/components/InstallOneLiner.tsx
+++ b/src/components/InstallOneLiner.tsx
@@ -10,17 +10,17 @@ const ONE_LINERS: Record<OS, {label: string; command: string; icon: typeof faLin
     linux: {
         label: 'Linux',
         icon: faLinux,
-        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad/master/bin/installer.sh | sh',
+        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad/develop/bin/installer.sh | sh',
     },
     mac: {
         label: 'macOS',
         icon: faApple,
-        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad/master/bin/installer.sh | sh',
+        command: 'curl -fsSL https://raw.githubusercontent.com/ether/etherpad/develop/bin/installer.sh | sh',
     },
     windows: {
         label: 'Windows',
         icon: faWindows,
-        command: 'irm https://raw.githubusercontent.com/ether/etherpad/master/bin/installer.ps1 | iex',
+        command: 'irm https://raw.githubusercontent.com/ether/etherpad/develop/bin/installer.ps1 | iex',
     },
 };
 


### PR DESCRIPTION
## Summary

Per #378, the homepage's copy-paste install commands hit 404:

\`\`\`sh
curl -fsSL https://raw.githubusercontent.com/ether/etherpad/master/bin/installer.sh | sh
# curl: (22) The requested URL returned error: 404
\`\`\`

\`ether/etherpad\`'s default branch is \`develop\`; there is no \`master\` branch. Updated all three \`InstallOneLiner\` URLs (\`installer.sh\` x2 and \`installer.ps1\`) to use \`develop\`. Verified \`develop/bin/installer.sh\` returns 200.

Closes #378

## Testing

\`\`\`
$ curl -sI https://raw.githubusercontent.com/ether/etherpad/develop/bin/installer.sh | head -1
HTTP/2 200
\`\`\`

Nothing else in the site touches those URLs.