### PR TITLE
feat(plugins): surface ep.json disables in plugin card

### DIFF
--- a/src/components/Plugin.tsx
+++ b/src/components/Plugin.tsx
@@ -78,6 +78,17 @@ export const PluginCom: FC<PluginProps> = ({plugins}) => {
             </div>
         </div>
         <div>{plugins.description}</div>
+        {plugins.disables && plugins.disables.length > 0 && (
+            <div
+                className="mt-2 px-3 py-2 rounded-md text-sm bg-amber-950/50 border border-amber-800/60 text-amber-200"
+                title="This plugin intentionally removes the listed Etherpad features. See doc/PLUGIN_FEATURE_DISABLES.md."
+            >
+                <span className="font-semibold">Disables: </span>
+                {plugins.disables
+                    .map((tag) => tag.replace(/^@feature:/, ''))
+                    .join(', ')}
+            </div>
+        )}
         <div className="flex gap-10">
             {plugins.images && plugins.images.map((img, i) => <img src={img} className="w-60 object-contain" key={plugins.name + i} alt={"Image of " + plugins.name}/>)}
             {plugins.readme && <div className="w-full line-clamp-5 readme-of-plugin"

--- a/src/store/Plugin.ts
+++ b/src/store/Plugin.ts
@@ -47,7 +47,23 @@ export type PluginResponseVal = {
         email: string
     },
     compatibility?: CompatibilityStatus,
-    images?: string[]
+    images?: string[],
+    /**
+     * `@feature:*` Playwright tags for core specs that the plugin
+     * intentionally disables. Sourced from the plugin's `ep.json`
+     * `disables` array; see ether/etherpad-lite#7648 and
+     * `doc/PLUGIN_FEATURE_DISABLES.md` for the contract.
+     *
+     * If present and non-empty, the plugin is one whose CI is permitted
+     * to skip specs tagged with these features — but is also required
+     * to make those specs FAIL (i.e. the plugin must actually disable
+     * what it declares). Surfaced in the plugin card so users see what
+     * a plugin removes before installing.
+     *
+     * May be undefined for plugins that don't disable any baseline
+     * feature, which is the common case.
+     */
+    disables?: string[]
 }
 
 


### PR DESCRIPTION
## Why

Plugins that intentionally remove a baseline Etherpad feature (`ep_disable_chat`, `ep_disable_change_author_name`, `ep_disable_error_messages`, …) currently look identical to neutral plugins on the listing page. A user installing one has no way to know it removes functionality until something stops working.

The companion proposal at [ether/etherpad-lite#7648](https://github.com/ether/etherpad-lite/pull/7648) introduces a small contract: plugins that disable a baseline feature declare it in their `ep.json`:

```json
{ "name": "ep_disable_chat", "disables": ["@feature:chat"], "parts": [...] }
```

That `disables` field is mechanically enforced by Etherpad's CI — a plugin can't ship green while quietly removing functionality it doesn't declare. This PR is the user-facing half: surface the declaration on etherpad.org/plugins so the contract is visible to humans too.

## Changes

- `src/store/Plugin.ts` — adds optional `disables?: string[]` to `PluginResponseVal` with a doc-comment pointing at the upstream contract.
- `src/components/Plugin.tsx` — renders an amber badge ("**Disables:** chat") under the description when `disables` is present and non-empty. Plugins without a `disables` field render unchanged.

## Safe to ship now

The UI change is independent of `plugins.viewer.json`'s build pipeline. Until that pipeline is updated to read `disables` from each plugin's `ep.json`, the new badge no-ops everywhere. As plugins start declaring disables (queued behind ether/etherpad-lite#7648), the badge lights up automatically.

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean.
- [x] Verified the badge no-ops when `disables` is missing or empty.
- [ ] Spot-check rendering against a synthetic `disables: ["@feature:chat"]` payload locally before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)