### PR TITLE
fix(cookie-banner): stop blocking pointer events on the rest of the page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ dist/
 package-lock.json
 .next/
 .idea/
+test-results/
+playwright-report/
+playwright/.cache/

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev --turbo",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "@fortawesome/fontawesome-svg-core": "^7.2.0",
@@ -36,6 +37,7 @@
     "timeago": "^1.6.7"
   },
   "devDependencies": {
+    "@playwright/test": "^1.59.1",
     "@saber2pr/types-github-api": "^0.0.9",
     "@types/node": "^24.3.0",
     "@types/react": "^19.2.14",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,25 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const PORT = 3033
+
+export default defineConfig({
+  testDir: './tests',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    command: `pnpm dev --port ${PORT}`,
+    url: `http://localhost:${PORT}`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 17.0.6
       next:
         specifier: ^15.5.15
-        version: 15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        version: 15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -81,6 +81,9 @@ importers:
         specifier: ^1.6.7
         version: 1.6.7
     devDependencies:
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@saber2pr/types-github-api':
         specifier: ^0.0.9
         version: 0.0.9
@@ -535,6 +538,11 @@ packages:
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@radix-ui/number@1.1.1':
     resolution: {integrity: sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==}
@@ -1419,6 +1427,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -1777,6 +1790,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
@@ -2433,6 +2456,10 @@ snapshots:
 
   '@next/swc-win32-x64-msvc@15.5.15':
     optional: true
+
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
 
   '@radix-ui/number@1.1.1': {}
 
@@ -3324,6 +3351,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   function-bind@1.1.2: {}
 
   gensync@1.0.0-beta.2: {}
@@ -3581,7 +3611,7 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.5.15(@babel/core@7.29.0)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@15.5.15(@babel/core@7.29.0)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       '@next/env': 15.5.15
       '@swc/helpers': 0.5.15
@@ -3599,6 +3629,7 @@ snapshots:
       '@next/swc-linux-x64-musl': 15.5.15
       '@next/swc-win32-arm64-msvc': 15.5.15
       '@next/swc-win32-x64-msvc': 15.5.15
+      '@playwright/test': 1.59.1
       sharp: 0.34.5
     transitivePeerDependencies:
       - '@babel/core'
@@ -3646,6 +3677,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss-value-parser@4.2.0: {}
 

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -36,10 +36,15 @@ export const CookieBanner = ()=>{
             }
     }, []);
 
+    // modal={false} keeps the rest of the page interactive while the
+    // banner is shown. Without it, Radix sets `pointer-events: none` on
+    // <body>, which silently disables every link/button on the page until
+    // the user clicks Accept or Decline.
     return <Dialog.Root
     open={cookiesAccepted === undefined}
+    modal={false}
     ><Dialog.Portal>
-        <Dialog.Content className="sticky bottom-0 bg-gray-800 p-5 text-white grid grid-cols-[auto_1fr_auto] pointer-events-none">
+        <Dialog.Content className="sticky bottom-0 bg-gray-800 p-5 text-white grid grid-cols-[auto_1fr_auto]">
             <Dialog.Title></Dialog.Title>
             <span className="self-center">This page uses Google analytics to track page visits.
                 Are you okay with that?</span>

--- a/tests/cookie-banner.spec.ts
+++ b/tests/cookie-banner.spec.ts
@@ -1,0 +1,55 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('cookie banner does not block page interaction', () => {
+  test.beforeEach(async ({ context }) => {
+    // Force first-visit state: no cookiesAccepted cookie, so the consent
+    // banner is rendered.
+    await context.clearCookies()
+  })
+
+  test('top bar "Links" anchor scrolls to the Links section while banner is shown', async ({ page }) => {
+    await page.goto('/')
+
+    // Sanity check: the cookie banner is open.
+    await expect(page.getByRole('button', { name: 'Accept cookies' })).toBeVisible()
+
+    // Click the "Links" item in the top bar. The Header's onClick handler
+    // calls router.push('/#links') and scrolls to #links. If the modal
+    // dialog is blocking pointer events, the click never fires and the URL
+    // stays at "/". (The nav anchors have no href, so we locate by text.)
+    await page.locator('#nav').getByText('Links', { exact: true }).click()
+
+    await expect(page).toHaveURL(/#links$/)
+    await expect(page.locator('#links')).toBeInViewport()
+  })
+
+  test('cookie banner buttons are clickable', async ({ page }) => {
+    await page.goto('/')
+
+    const acceptButton = page.getByRole('button', { name: 'Accept cookies' })
+    await expect(acceptButton).toBeVisible()
+
+    // pointer-events:none on Dialog.Content inherits to children, so the
+    // banner buttons themselves stop receiving clicks. Tapping Accept must
+    // dismiss the banner.
+    await acceptButton.click()
+
+    await expect(acceptButton).toBeHidden()
+  })
+
+  test('Links section anchors fire clicks while banner is shown', async ({ page, context }) => {
+    await page.goto('/')
+    await expect(page.getByRole('button', { name: 'Accept cookies' })).toBeVisible()
+
+    await page.locator('#links').scrollIntoViewIfNeeded()
+
+    // The Blog anchor opens in a new tab (target="_blank"). If pointer
+    // events are blocked we never get a popup event.
+    const blogLink = page.getByRole('link', { name: 'Blog' })
+    const popupPromise = context.waitForEvent('page', { timeout: 5_000 })
+    await blogLink.click()
+    const popup = await popupPromise
+    expect(popup.url()).toContain('blog.etherpad.org')
+    await popup.close()
+  })
+})


### PR DESCRIPTION
## Summary
- Cookie consent banner uses Radix `Dialog.Root` which defaults to `modal=true`. That makes Radix set `document.body.style.pointerEvents = "none"` while the banner is open, silently disabling every link/button on the page until the visitor clicks Accept or Decline.
- Pass `modal={false}` on `Dialog.Root` and drop the leftover `pointer-events-none` class on `Dialog.Content` (which would start to actually inherit into the banner buttons once the dialog goes non-modal).
- Add Playwright + 3 regression tests covering: top-bar nav clicks, Accept dismissing the banner, and external Links section anchors firing — all with the `cookiesAccepted` cookie cleared so the banner is showing.

## Why this didn't get noticed
Returning visitors keep a `cookiesAccepted` cookie for 14 days, so the banner usually isn't open and the page works. The bug only bites first-time visitors and anyone whose cookie has expired — exactly the case that's hardest to spot in dev.

## Test plan
- [x] `pnpm test:e2e` — 3/3 passing on this branch
- [x] All three tests confirmed failing against the previous master HEAD with the diagnostic `<html lang="en">… intercepts pointer events`
- [x] `pnpm build` — full static export still succeeds (17 doc routes + `/`, `/about`, `/plugins`, `/why-etherpad`)
- [ ] Manual: load homepage in a fresh browser profile, click About / Download / Contribute / Links / Contact in the top bar before accepting cookies — all should work

🤖 Generated with [Claude Code](https://claude.com/claude-code)