### PR TITLE
docs: bump install one-liner minimum to Node.js 25

### DIFF
--- a/src/components/InstallOneLiner.tsx
+++ b/src/components/InstallOneLiner.tsx
@@ -70,7 +70,7 @@ export const InstallOneLiner = () => {
             </button>
         </div>
         <p className="text-xs text-gray-500 dark:text-gray-400 px-3 pb-3">
-            Needs <code>git</code> and Node.js &ge; 20. Then <code>cd etherpad && pnpm run prod</code> and open <code>http://localhost:9001</code>.{' '}
+            Needs <code>git</code> and Node.js &ge; 25. Then <code>cd etherpad && pnpm run prod</code> and open <code>http://localhost:9001</code>.{' '}
             <a
                 href="https://github.com/ether/etherpad#installation"
                 target="_blank"


### PR DESCRIPTION
## Summary
- Update the homepage install hint from `Node.js >= 20` to `Node.js >= 25`, matching the new project-wide runtime floor being rolled out across ether/etherpad CI and docs.

## Test plan
- [ ] Visual check that the install card on the homepage reads "Needs git and Node.js >= 25."
- [ ] Confirm no other version mentions in `docs-content/` or `src/pagesToDisplay/` need updating (audited; this was the only one).

🤖 Generated with [Claude Code](https://claude.com/claude-code)