### PR TITLE
docs: bump install one-liner back to Node.js >= 24

### DIFF
--- a/src/components/InstallOneLiner.tsx
+++ b/src/components/InstallOneLiner.tsx
@@ -70,7 +70,7 @@ export const InstallOneLiner = () => {
             </button>
         </div>
         <p className="text-xs text-gray-500 dark:text-gray-400 px-3 pb-3">
-            Needs <code>git</code> and Node.js &ge; 25. Then <code>cd etherpad && pnpm run prod</code> and open <code>http://localhost:9001</code>.{' '}
+            Needs <code>git</code> and Node.js &ge; 24. Then <code>cd etherpad && pnpm run prod</code> and open <code>http://localhost:9001</code>.{' '}
             <a
                 href="https://github.com/ether/etherpad#installation"
                 target="_blank"


### PR DESCRIPTION
## Summary
Companion to ether/etherpad#7781 (closes ether/etherpad#7779).

Node 25 hit end-of-life on **April 10 2026**, so the runtime floor set by #402 on the homepage points at an already-EOL major. Roll back to Node 24, which is the current **Active LTS** (supported until ~May 2028).

Single-line change in `src/components/InstallOneLiner.tsx`: `Node.js >= 25` -> `Node.js >= 24`.

## Test plan
- [ ] Visual check on the homepage install card reads "Needs `git` and Node.js >= 24."

🤖 Generated with [Claude Code](https://claude.com/claude-code)