### PR TITLE
Add "More from Etherpad" ecosystem section to homepage

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -8,6 +8,7 @@ import {AIOnYourTerms} from "../src/pagesToDisplay/AIOnYourTerms.tsx";
 import {AddFunctionalities} from "../src/pagesToDisplay/AddFunctionalities.tsx";
 import {CustomizeAppearance} from "../src/pagesToDisplay/CustomizeAppearance.tsx";
 import {DownloadLatestVersion} from "../src/pagesToDisplay/DownloadLatestVersion.tsx";
+import {EtherpadEcosystem} from "../src/pagesToDisplay/EtherpadEcosystem.tsx";
 import {Contribute} from "../src/pagesToDisplay/Contribute.tsx";
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
 import {faExternalLink} from "@fortawesome/free-solid-svg-icons";
@@ -38,6 +39,8 @@ export default function Page() {
             <CustomizeAppearance/>
             <a className="scroll-point" id="download"></a>
             <DownloadLatestVersion/>
+            <a className="scroll-point" id="ecosystem"></a>
+            <EtherpadEcosystem/>
             <a className="scroll-point" id="contribute"></a>
             <Contribute/>
             <a className="scroll-point" id="links"></a>

--- a/src/Constants.ts
+++ b/src/Constants.ts
@@ -18,4 +18,9 @@ export const DOC_PAGE = `/doc/v${CURRENT_VERSION}/index.html`
 
 export const GITHUB_HELP = "https://docs.github.com"
 
+// Official companion apps, clients and tools maintained by the Etherpad
+// Foundation alongside the core editor. Plugins are intentionally excluded
+// here — they live on the dedicated /plugins page.
+export const ETHERPAD_ORG = "https://github.com/ether"
+
 export const TRACKING_ID = 'UA-19303815-1'

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -44,7 +44,7 @@ export const MobileDrawer:FC<MobileDrawerProps> = ({isOpen, setOpen}) => {
                 </div>
                 <div className="contents"  onClick={()=>navigateToElement('ecosystem')}>
                     <FontAwesomeIcon icon={faCubes} className="self-center"/>
-                    <a title="apps and tools">Apps &amp; Tools</a>
+                    <a href="/#ecosystem" onClick={(e)=>{e.preventDefault(); navigateToElement('ecosystem')}} title="apps and tools">Apps &amp; Tools</a>
                 </div>
                 <div className="contents"  onClick={()=>navigateToElement('contribute')}>
                         <FontAwesomeIcon icon={faWrench} className="self-center"/>

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -1,6 +1,6 @@
 'use client'
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
-import {faInfoCircle, faDownload, faWrench, faExternalLink, faContactCard} from '@fortawesome/free-solid-svg-icons'
+import {faInfoCircle, faDownload, faWrench, faExternalLink, faContactCard, faCubes} from '@fortawesome/free-solid-svg-icons'
 import {FC, useEffect} from "react";
 import {ThemeToggler} from "./ThemeToggler.tsx";
 import {useUIStore} from "../store/store.ts";
@@ -41,6 +41,10 @@ export const MobileDrawer:FC<MobileDrawerProps> = ({isOpen, setOpen}) => {
                 <div className="contents"  onClick={()=>navigateToElement('download')}>
                     <FontAwesomeIcon icon={faDownload} className="self-center"/>
                     <a title="download">Download</a>
+                </div>
+                <div className="contents"  onClick={()=>navigateToElement('ecosystem')}>
+                    <FontAwesomeIcon icon={faCubes} className="self-center"/>
+                    <a title="apps and tools">Apps &amp; Tools</a>
                 </div>
                 <div className="contents"  onClick={()=>navigateToElement('contribute')}>
                         <FontAwesomeIcon icon={faWrench} className="self-center"/>

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -1,4 +1,5 @@
 import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import Link from "next/link";
 import type {IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import {
     faCubes,
@@ -89,7 +90,7 @@ export const EtherpadEcosystem = () => {
         <p className="dark:text-gray-400">
             Etherpad is more than the editor. The Foundation maintains a family of official
             apps, clients and tools to help you run, embed and scale Etherpad. Looking for
-            plugins instead? Browse the <a className="underline" href="/plugins">plugin directory</a>.
+            plugins instead? Browse the <Link className="underline" href="/plugins">plugin directory</Link>.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
             {PROJECTS.map((project) => (

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -9,6 +9,7 @@ import {
     faDatabase,
     faCode,
     faHouse,
+    faCalculator,
 } from "@fortawesome/free-solid-svg-icons";
 import {ETHERPAD_ORG} from "../Constants.ts";
 
@@ -45,6 +46,12 @@ const PROJECTS: EcosystemProject[] = [
         url: `${ETHERPAD_ORG}/etherpad-load-test`,
         icon: faGaugeHigh,
         description: "Simulate many concurrent users hammering a pad so you can size and tune your instance before going live.",
+    },
+    {
+        name: "Scale Calculator",
+        url: "https://scale.etherpad.org",
+        icon: faCalculator,
+        description: "Estimate the CPU, memory and number of instances your deployment needs for a target number of concurrent users.",
     },
     {
         name: "ueberDB",

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -1,0 +1,102 @@
+import {FontAwesomeIcon} from "@fortawesome/react-fontawesome";
+import type {IconDefinition} from "@fortawesome/fontawesome-svg-core";
+import {
+    faCubes,
+    faDesktop,
+    faTerminal,
+    faNetworkWired,
+    faGaugeHigh,
+    faDatabase,
+    faCode,
+    faHouse,
+} from "@fortawesome/free-solid-svg-icons";
+import {ETHERPAD_ORG} from "../Constants.ts";
+
+type EcosystemProject = {
+    name: string,
+    url: string,
+    icon: IconDefinition,
+    description: string,
+}
+
+// Curated, user-facing companion projects from the Etherpad Foundation.
+// Plugins are deliberately left out — they have their own /plugins page.
+const PROJECTS: EcosystemProject[] = [
+    {
+        name: "Desktop & Mobile App",
+        url: `${ETHERPAD_ORG}/etherpad-desktop`,
+        icon: faDesktop,
+        description: "Run Etherpad as a native app on Windows, macOS, Linux, Android and iOS — collaborate without opening a browser.",
+    },
+    {
+        name: "Command-line Client",
+        url: `${ETHERPAD_ORG}/etherpad-cli`,
+        icon: faTerminal,
+        description: "Create, read and edit pads straight from your terminal. Great for scripting and automating your Etherpad instance.",
+    },
+    {
+        name: "Socket.IO Proxy",
+        url: `${ETHERPAD_ORG}/etherpad-proxy`,
+        icon: faNetworkWired,
+        description: "A reference proxy for Etherpad's real-time Socket.IO traffic — a starting point for inspecting or routing pad messages.",
+    },
+    {
+        name: "Load Testing Tool",
+        url: `${ETHERPAD_ORG}/etherpad-load-test`,
+        icon: faGaugeHigh,
+        description: "Simulate many concurrent users hammering a pad so you can size and tune your instance before going live.",
+    },
+    {
+        name: "ueberDB",
+        url: `${ETHERPAD_ORG}/ueberDB`,
+        icon: faDatabase,
+        description: "The database abstraction layer that powers Etherpad — one API over MySQL, PostgreSQL, Redis, MongoDB, SQLite and more.",
+    },
+    {
+        name: "Web Components",
+        url: `${ETHERPAD_ORG}/webcomponents`,
+        icon: faCode,
+        description: "Embed a live Etherpad pad anywhere with a simple custom HTML element — drop it into your own site or app.",
+    },
+    {
+        name: "Home Assistant Add-on",
+        url: `${ETHERPAD_ORG}/home-assistant-addon-etherpad`,
+        icon: faHouse,
+        description: "Self-host Etherpad on your Home Assistant box in a couple of clicks — collaborative notes for your smart home.",
+    },
+]
+
+export const EtherpadEcosystem = () => {
+    return <div className="content wrap">
+        <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
+            <FontAwesomeIcon icon={faCubes} className="mr-4"/>
+            More from Etherpad
+        </h2>
+        <p className="dark:text-gray-400">
+            Etherpad is more than the editor. The Foundation maintains a family of official
+            apps, clients and tools to help you run, embed and scale Etherpad. Looking for
+            plugins instead? Browse the <a className="underline" href="/plugins">plugin directory</a>.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
+            {PROJECTS.map((project) => (
+                <a
+                    key={project.url}
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="group flex flex-col h-full p-5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 transition-shadow hover:shadow-md focus:shadow-md no-underline"
+                >
+                    <div className="flex items-center mb-2">
+                        <FontAwesomeIcon icon={project.icon} className="text-2xl text-primary mr-3"/>
+                        <span className="text-lg font-bold text-gray-800 dark:text-white group-hover:text-primary">
+                            {project.name}
+                        </span>
+                    </div>
+                    <span className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+                        {project.description}
+                    </span>
+                </a>
+            ))}
+        </div>
+    </div>
+}

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -40,7 +40,7 @@ const PROJECTS: EcosystemProject[] = [
         name: "pad — Terminal Editor",
         url: `${ETHERPAD_ORG}/pad`,
         icon: faKeyboard,
-        description: "A nano-class terminal text editor. Edit files locally, or join any pad over the network and watch collaborators' edits land live in your terminal.",
+        description: "A nano-class terminal text editor. Edit files locally, or join any pad to collaborate in real time — your edits and everyone else's sync live, right in your terminal.",
     },
     {
         name: "Printing Press",

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type {IconDefinition} from "@fortawesome/fontawesome-svg-core";
 import {
     faCubes,
+    faPlug,
     faDesktop,
     faTerminal,
     faNetworkWired,
@@ -19,11 +20,21 @@ type EcosystemProject = {
     url: string,
     icon: IconDefinition,
     description: string,
+    // Internal routes (e.g. /plugins) use next/link for client-side
+    // navigation; everything else opens the external project in a new tab.
+    internal?: boolean,
 }
 
-// Curated, user-facing companion projects from the Etherpad Foundation.
-// Plugins are deliberately left out — they have their own /plugins page.
+// Curated, user-facing companion projects and resources from the Etherpad
+// Foundation, surfaced alongside the core editor on the homepage.
 const PROJECTS: EcosystemProject[] = [
+    {
+        name: "Plugins",
+        url: "/plugins",
+        icon: faPlug,
+        description: "Hundreds of community plugins add features, themes and integrations. Browse the directory and extend your Etherpad however you like.",
+        internal: true,
+    },
     {
         name: "Desktop & Mobile App",
         url: `${ETHERPAD_ORG}/etherpad-desktop`,
@@ -74,6 +85,20 @@ const PROJECTS: EcosystemProject[] = [
     },
 ]
 
+const CARD_CLASS = "group flex flex-col h-full p-5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 transition-shadow hover:shadow-md focus:shadow-md no-underline"
+
+const CardBody = ({project}: {project: EcosystemProject}) => <>
+    <div className="flex items-center mb-2">
+        <FontAwesomeIcon icon={project.icon} className="text-2xl text-primary mr-3"/>
+        <span className="text-lg font-bold text-gray-800 dark:text-white group-hover:text-primary">
+            {project.name}
+        </span>
+    </div>
+    <span className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
+        {project.description}
+    </span>
+</>
+
 export const EtherpadEcosystem = () => {
     return <div className="content wrap">
         <h2 className="text-3xl text-primary font-bold mb-4 mt-16 flex items-center">
@@ -82,28 +107,26 @@ export const EtherpadEcosystem = () => {
         </h2>
         <p className="dark:text-gray-400">
             Etherpad is more than the editor. The Foundation maintains a family of official
-            apps, clients and tools to help you run, embed and scale Etherpad. Looking for
-            plugins instead? Browse the <Link className="underline" href="/plugins">plugin directory</Link>.
+            apps, clients and tools — plus a large plugin ecosystem — to help you extend, run,
+            embed and scale Etherpad.
         </p>
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mt-6">
             {PROJECTS.map((project) => (
-                <a
-                    key={project.url}
-                    href={project.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="group flex flex-col h-full p-5 rounded-lg border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-700 transition-shadow hover:shadow-md focus:shadow-md no-underline"
-                >
-                    <div className="flex items-center mb-2">
-                        <FontAwesomeIcon icon={project.icon} className="text-2xl text-primary mr-3"/>
-                        <span className="text-lg font-bold text-gray-800 dark:text-white group-hover:text-primary">
-                            {project.name}
-                        </span>
-                    </div>
-                    <span className="text-sm text-gray-600 dark:text-gray-300 leading-relaxed">
-                        {project.description}
-                    </span>
-                </a>
+                project.internal ? (
+                    <Link key={project.url} href={project.url} className={CARD_CLASS}>
+                        <CardBody project={project}/>
+                    </Link>
+                ) : (
+                    <a
+                        key={project.url}
+                        href={project.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={CARD_CLASS}
+                    >
+                        <CardBody project={project}/>
+                    </a>
+                )
             ))}
         </div>
     </div>

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -7,7 +7,6 @@ import {
     faTerminal,
     faNetworkWired,
     faDatabase,
-    faCode,
     faHouse,
     faCalculator,
     faKeyboard,
@@ -66,12 +65,6 @@ const PROJECTS: EcosystemProject[] = [
         url: `${ETHERPAD_ORG}/ueberDB`,
         icon: faDatabase,
         description: "The database abstraction layer that powers Etherpad — one API over MySQL, PostgreSQL, Redis, MongoDB, SQLite and more.",
-    },
-    {
-        name: "Web Components",
-        url: `${ETHERPAD_ORG}/webcomponents`,
-        icon: faCode,
-        description: "Embed a live Etherpad pad anywhere with a simple custom HTML element — drop it into your own site or app.",
     },
     {
         name: "Home Assistant Add-on",

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -5,7 +5,6 @@ import {
     faDesktop,
     faTerminal,
     faNetworkWired,
-    faGaugeHigh,
     faDatabase,
     faCode,
     faHouse,
@@ -54,12 +53,6 @@ const PROJECTS: EcosystemProject[] = [
         url: `${ETHERPAD_ORG}/etherpad-proxy`,
         icon: faNetworkWired,
         description: "A reference proxy for Etherpad's real-time Socket.IO traffic — a starting point for inspecting or routing pad messages.",
-    },
-    {
-        name: "Load Testing Tool",
-        url: `${ETHERPAD_ORG}/etherpad-load-test`,
-        icon: faGaugeHigh,
-        description: "Simulate many concurrent users hammering a pad so you can size and tune your instance before going live.",
     },
     {
         name: "Scale Calculator",

--- a/src/pagesToDisplay/EtherpadEcosystem.tsx
+++ b/src/pagesToDisplay/EtherpadEcosystem.tsx
@@ -10,6 +10,8 @@ import {
     faCode,
     faHouse,
     faCalculator,
+    faKeyboard,
+    faRobot,
 } from "@fortawesome/free-solid-svg-icons";
 import {ETHERPAD_ORG} from "../Constants.ts";
 
@@ -34,6 +36,18 @@ const PROJECTS: EcosystemProject[] = [
         url: `${ETHERPAD_ORG}/etherpad-cli`,
         icon: faTerminal,
         description: "Create, read and edit pads straight from your terminal. Great for scripting and automating your Etherpad instance.",
+    },
+    {
+        name: "pad — Terminal Editor",
+        url: `${ETHERPAD_ORG}/pad`,
+        icon: faKeyboard,
+        description: "A nano-class terminal text editor. Edit files locally, or join any pad over the network and watch collaborators' edits land live in your terminal.",
+    },
+    {
+        name: "Printing Press",
+        url: "https://printingpress.dev",
+        icon: faRobot,
+        description: "Agent-native Etherpad tooling — a Go CLI, a Claude Code skill and an MCP server, generated from a spec so AI agents can drive Etherpad.",
     },
     {
         name: "Socket.IO Proxy",

--- a/src/pagesToDisplay/Header.tsx
+++ b/src/pagesToDisplay/Header.tsx
@@ -38,7 +38,7 @@ export const Header = () => {
                 <ul>
                     <li><Link className="text-[#555] dark:text-white" href="/about" title="about">About</Link></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('download')} title="download">Download</a></li>
-                    <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('ecosystem')} title="apps and tools">Apps &amp; Tools</a></li>
+                    <li><a className="text-[#555] dark:text-white" href="/#ecosystem" onClick={(e)=>{e.preventDefault(); navigateToElement('ecosystem')}} title="apps and tools">Apps &amp; Tools</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('contribute')} title="contribute">Contribute</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement("links")} title="links">Links</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('contact')} title="contact">Contact</a></li>

--- a/src/pagesToDisplay/Header.tsx
+++ b/src/pagesToDisplay/Header.tsx
@@ -38,6 +38,7 @@ export const Header = () => {
                 <ul>
                     <li><Link className="text-[#555] dark:text-white" href="/about" title="about">About</Link></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('download')} title="download">Download</a></li>
+                    <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('ecosystem')} title="apps and tools">Apps &amp; Tools</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('contribute')} title="contribute">Contribute</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement("links")} title="links">Links</a></li>
                     <li><a className="text-[#555] dark:text-white" onClick={()=>navigateToElement('contact')} title="contact">Contact</a></li>


### PR DESCRIPTION
## What

etherpad.org currently links to the core editor, the blog, the wiki and the plugin directory — but nowhere does it point visitors at the **other official projects the Foundation maintains**. People don't discover [etherpad-desktop](https://github.com/ether/etherpad-desktop), [etherpad-cli](https://github.com/ether/etherpad-cli), [pad](https://github.com/ether/pad) and friends because the site never mentions them.

This adds a **"More from Etherpad"** section to the homepage: a responsive card grid of the Foundation's user-facing companion apps, clients and tools.

## Where

- New section sits between **Download** and **Contribute** (scroll-point `id="ecosystem"`).
- New **"Apps & Tools"** entry in the desktop nav (`Header.tsx`) and the mobile drawer (`MobileDrawer.tsx`).
- The intro copy links back to the existing `/plugins` page so the two stay distinct.

## What's featured

Curated, user-facing projects (plugins keep their own `/plugins` page and are intentionally excluded):

| Project | Links to |
|---|---|
| Plugins | `/plugins` (internal) |
| Desktop & Mobile App | `ether/etherpad-desktop` |
| Command-line Client | `ether/etherpad-cli` |
| pad — Terminal Editor | `ether/pad` |
| Printing Press | printingpress.dev |
| Socket.IO Proxy | `ether/etherpad-proxy` |
| Scale Calculator | scale.etherpad.org |
| ueberDB | `ether/ueberDB` |
| Home Assistant Add-on | `ether/home-assistant-addon-etherpad` |

The card list is a single data array in `EtherpadEcosystem.tsx`, so adding/removing entries later is a one-line change.

## How it looks

Cards are a 1 / 2 / 3-column Tailwind grid reusing the existing section styling, with hover elevation and full light/dark support.

**Light:**

![ecosystem section, light mode](https://raw.githubusercontent.com/JohnMcLear/ether.github.com/eco-pr-assets/ecosystem-light.png)

**Dark:**

![ecosystem section, dark mode](https://raw.githubusercontent.com/JohnMcLear/ether.github.com/eco-pr-assets/ecosystem-dark.png)

## Verification

- `next build` (with type-checking) passes.
- Rendered the exported static `dist` in Chromium and verified the section renders correctly, the "Apps & Tools" nav entry works, and both light and dark themes look right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)